### PR TITLE
Fix explanation for UsersTableSeeder

### DIFF
--- a/content/how-to-build-a-graphql-server-using-laravel-part-2/index.md
+++ b/content/how-to-build-a-graphql-server-using-laravel-part-2/index.md
@@ -265,6 +265,12 @@ class UsersTableSeeder extends Seeder
     public function run()
     {
         $faker = \Faker\Factory::create();
+        
+        User::create([
+            'name' => $faker->name,
+            'email' => 'me@mygraphqlapp.com',
+            'password' => bcrypt('secret')
+        ]);
 
         factory(User::class, 50)->create()->each(function($user) use ($faker){
             for ($i=0; $i < 5; $i++) {
@@ -275,12 +281,6 @@ class UsersTableSeeder extends Seeder
                 ]);
             }
         });
-
-        User::create([
-            'name' => $faker->name,
-            'email' => 'me@mygraphqlapp.com',
-            'password' => bcrypt('secret')
-        ]);
     }
 }
 ```


### PR DESCRIPTION
The explanation given to the `UsersTableSeeder` seemed to be interchanged in terms of order of code execution.
With the original code, the *50 random users* will be created first along with 5 articles each, before creating an *additional user* with an email of `me@mygraphqlapp.com` which is an opposite of what the original explanation gave. So in this PR I just interchanged the order of the code (which is much easier) to match the explanation.